### PR TITLE
release 1.0-22

### DIFF
--- a/eayunstack-tools.spec
+++ b/eayunstack-tools.spec
@@ -1,6 +1,6 @@
 Name:		eayunstack-tools
 Version:	1.0
-Release:	21%{?dist}
+Release:	22%{?dist}
 Summary:	EayunStack Management tools
 
 Group:		Application
@@ -73,6 +73,9 @@ fi
 
 
 %changelog
+* Tue Aug 18 2015 blkart <blkart.org@gmail.com> 1.0-22
+- commit c1fa414a4a76f93ee408b8ddc25c2615693958c2
+
 * Tue Aug 4 2015 blkart <blkart.org@gmail.com> 1.0-21
 - commit fb21b14762ae9e51b0ea727ad1a0a12dc877122b
 


### PR DESCRIPTION
1.net: 某些 neutronclient 版本不支持 json 和 csv 格式
2.net: 外网的port没有意义
3.net: 某些错误的 router 得不到 l3_host
4.Revert "[doctor utils] 服务检测错误日志信息中增加节点主机名信息"
5.utils: log 模块和utils模块互相不能import，将需要 import 的utils代码抽离出来
6.volume: global_id 需要声明
7.log: log 中加上主机明和角色信息
8.doctor: ceph 出错了显示详细出错信息

Signed-off-by: blkart blkart.org@gmail.com
