### PR TITLE
[bugfix] fix `eayunstack init` run on fuel ERROR

### DIFF
--- a/eayunstack_tools/init/__init__.py
+++ b/eayunstack_tools/init/__init__.py
@@ -52,15 +52,9 @@ def init_node_list_file():
         fqdn = node['fqdn']
         ip = node['ip']
         ips.append(ip)
-        roles = ''
-        if len(node['roles']) > 1:
-            for n in node['roles']: 
-                if not roles:
-                    roles = roles + n
-                else:
-                    roles = roles + ',' + n
-        else:
-            roles = node['roles'][0]
+        roles = ','.join(node['roles'])
+        if not roles:
+            continue
         host = fqdn.split('.')[0]
         mac = node['mac'].replace(':', '.')
         idrac_addr = get_idrac_addr(ip)


### PR DESCRIPTION
Ignore the node in discover status when run eayunstack init command.

redmine 7588

Signed-off-by: blkart blkart.org@gmail.com
